### PR TITLE
Force light theme for YinYangAnimationView

### DIFF
--- a/SwiftUI-Animations/Code/Common/Animations/YinYang-Toggle/Views/YinYangAnimationView.swift
+++ b/SwiftUI-Animations/Code/Common/Animations/YinYang-Toggle/Views/YinYangAnimationView.swift
@@ -15,10 +15,6 @@ struct YinYangAnimationView: View {
     
     // MARK: - Variables
     
-    /// Used to read the current system color scheme (light/dark),
-    /// though visual theming is driven by `yinYangViewModel.themeToggled` instead.
-    @Environment(\.colorScheme) var colorScheme
-    
     /// The shared view model that owns the toggle state and is passed
     /// down the view hierarchy via the environment.
     @State var yinYangViewModel: YinYangViewModel = .init()
@@ -79,6 +75,7 @@ struct YinYangAnimationView: View {
                     .padding(.top, 54)
             }
         }
+        .environment(\.colorScheme, .light)
         // Inject the view model so child views (e.g. YinToggleView) can read it
         .environment(yinYangViewModel)
         .onAppear {


### PR DESCRIPTION
resolves #28

## What does this PR do?

forces light theme to the animation for dark theme users

## Type of Change

- [ ] New animation
- [ ] Bug fix
- [x] Improvement to existing animation
- [ ] Documentation update
- [ ] Other (please describe)

## Animation Preview


https://github.com/user-attachments/assets/29828967-eaa1-4e9f-b561-bdec3a61db89


## Checklist

- [ ] Animation is self-contained in its own folder under `Code/Animations/`
- [ ] Custom shapes are in a `Support Shapes/` subfolder (if applicable)
- [ ] GIF preview added to `GIFs/` folder
- [ ] README gallery table updated with new entry
- [ ] Code compiles without warnings on iOS 14+
- [ ] No UIKit bridges used (unless absolutely necessary)
- [x] Tested on at least one simulator

## Related Issues

resolves #28 